### PR TITLE
Fix a loading error in magit-log-date-headers-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -1341,7 +1341,7 @@ Add date headers to Magit log buffers.
   (define-minor-mode unpackaged/magit-log-date-headers-mode
     "Display date/time headers in `magit-log' buffers."
     :global t
-    (if magit-log-date-headers-mode
+    (if unpackaged/magit-log-date-headers-mode
         (progn
           ;; Enable mode
           (add-hook 'magit-post-refresh-hook #'unpackaged/magit-log--add-date-headers)

--- a/unpackaged.el
+++ b/unpackaged.el
@@ -944,7 +944,7 @@ command was called, go to its unstaged changes section."
 (define-minor-mode unpackaged/magit-log-date-headers-mode
   "Display date/time headers in `magit-log' buffers."
   :global t
-  (if magit-log-date-headers-mode
+  (if unpackaged/magit-log-date-headers-mode
       (progn
         ;; Enable mode
         (add-hook 'magit-post-refresh-hook #'unpackaged/magit-log--add-date-headers)


### PR DESCRIPTION
`unpackaged/` prefix was missing in `magit-log-date-headers-mode`, which caused the following error. I have fixed the issue.

> Symbol’s value as variable is void: magit-log-date-headers-mode