### PR TITLE
Check if iedit-mode is bound when running iedit-or-flyspell

### DIFF
--- a/README.org
+++ b/README.org
@@ -1160,7 +1160,7 @@ With point in code or when ~iedit-mode~ is already active, toggle ~iedit-mode~. 
   misspelled word with `flyspell'.  Call this command a second time
   to choose a different correction."
     (interactive)
-    (if (or iedit-mode
+    (if (or (bound-and-true-p iedit-mode)
             (and (derived-mode-p 'prog-mode)
                  (not (or (nth 4 (syntax-ppss))
                           (nth 3 (syntax-ppss))))))

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
-<!-- 2019-01-14 Mon 17:44 -->
+<!-- 2019-01-31 Thu 21:41 -->
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>unpackaged.el</title>

--- a/unpackaged.el
+++ b/unpackaged.el
@@ -804,7 +804,7 @@ With point in code or when `iedit-mode' is already active, toggle
 misspelled word with `flyspell'.  Call this command a second time
 to choose a different correction."
   (interactive)
-  (if (or iedit-mode
+  (if (or (bound-and-true-p iedit-mode)
           (and (derived-mode-p 'prog-mode)
                (not (or (nth 4 (syntax-ppss))
                         (nth 3 (syntax-ppss))))))


### PR DESCRIPTION
`unpackaged/iedit-or-flyspell` can sometimes raise an error, since `iedit-mode` is unbound if the user have never run iedit in the current Emacs session. This can be problematic whether the user wants to run iedit or flyspell using this command. To prevent the error, you have to check if `iedit-mode` is bound before checking if the variable is non-nil, and `bound-and-true-p` does both in a single function.