### PR TITLE
Fix repository's language classification on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Stop HTML documents from skewing the repository's language stats
+*.html linguist-documentation=true


### PR DESCRIPTION
GitHub currently tags this repo as comprising 81.5% HTML code, instead of Emacs Lisp being the most dominant language. Now, the [library](https://github.com/github/linguist) used on GitHub for language analysis has a number of overrides to fix situations like this, called [overrides](https://github.com/github/linguist#overrides).

<details>
<summary><b>EDIT:</b> Removed image optimisation through hard reset, as requested.</summary>

### Original addendum:

> I also couldn't help running the PNG images through [TinyPNG.com](https://tinypng.com/) to shave off some bytes (the savings are in the spiffy commit notes of 050b753).
>
> ~~~
> commit bf2879927eba82b328901f8de8f343ecf6e4cc8e
> Author: Alhadis <gardnerjohng@gmail.com>
> Date:   Fri Mar 1 14:12:04 2019 +1100
> 
>     Shrink filesizes of PNG images using TinyPNG.com
>     
>     ╒═══════════════════════════════╤═════════════════════════════╕
>     │ FILENAMES                     │     FILESIZE REDUCTIONS     │
>     ╞═══════════════════════════════╪══════════════════════╤══════╡
>     │ dont-tread-on-emacs-150.png   │   4.8 KBs → 2.5  KBs │ -49% │
>     │ font-compare.png              │  49.9 KBs → 26.2 KBs │ -48% │
>     │ magit-log-date-headers.png    │ 116.1 KBs → 30.5 KBs │ -74% │
>     │ org-agenda-preview-after.png  │  20.2 KBs → 7.7  KBs │ -62% │
>     │ org-agenda-preview-before.png │  26.1 KBs → 9.4  KBs │ -64% │
>     │ smerge-mode-hydra.png         │  65.4 KBs → 21.4 KBs │ -67% │
>     └───────────────────────────────┼──────────────────────┼──────┤
>                                     │ TOTAL:      -185 KBs │ -65% │
>                                     └──────────────────────┴──────┘
> ~~~

</details>