### PR TITLE
Under Packages: defvar-maybe and defvar-changedef

### DIFF
--- a/README.org
+++ b/README.org
@@ -1277,6 +1277,78 @@ Mark current package for upgrading (i.e. also mark obsolete version for deletion
             (forward-line 1))))))
 #+END_SRC
 
+** Emacs Lisp Package Development
+
+*** Always document variables
+
+A drop in replacement to defvar (or defcustom) and a function to strip
+it back out of your package source once things are stable.  Use this
+to document your variables from the beginning of package development
+when the additional design introspection will do you the most good.
+
+Implicitly reset all formally declared variables to their default
+bindings by setting the buffer local variable 'defmaybe-defvar' to nil
+and then using eval-buffer, eval-region, &ct as normal.
+
+#+BEGIN_SRC elisp
+  (defvar-local defmaybe-defvar nil
+    "Local. Controls func: `defvar-maybe', which see for detail.")
+  (defmacro defvar-maybe (var-name &optional i-value d-string &rest customize-options)
+    "Create or set a variable per the buffer-local `defmaybe-defvar'.
+
+  Use `setq' instead of `defvar' when `defmaybe-defvar' is not
+  truthy.  When `defmaybe-defvar' is `custom use `defcustom'.
+
+  VAR-NAME is the symbol to declare or set.  I-VALUE is either
+  INITVALUE for `defvar' or VAL for `setq'.  D-STRING is DOCSTRING
+  when `defvar' is used.  CUSTOMIZE-OPTIONS are ARES to `defcustom'.
+
+  This is useful when using `eval-buffer' to run test cases hacked
+  directly into a package's source files."
+    (declare (indent 2) (doc-string 3))
+  ;;;  (message "devel:%s (%s)" defmaybe-defvar (and (boundp #'defmaybe-defvar) defmaybe-defvar))
+    (if (and (boundp #'defmaybe-defvar)
+	     defmaybe-defvar)
+	(if (eq 'custom defmaybe-defvar)
+	    `(defcustom ,var-name ,i-value ,d-string ,@customize-options)
+	  `(defvar ,var-name ,i-value ,d-string))
+      `(setq ,var-name ,i-value)))
+
+  (defun defvar-changedef (old new &optional max-forms)
+    "Replace car of each top-level sexp in `current-buffer'.
+
+OLD is the current car of target expressions tested using
+`string-equal'.  OLD is the replacement.  If MAX-FORMS is
+non-nil, limit forms fowlling NEW to this number. Use this to
+supress extra arguments required by old but not accepted by NEW.
+TODO: just set car of `sexp-at-point' to NEW when it is OLD."
+    ;;(sexp-at-point
+    ;;(read
+    (save-excursion
+      (let ((count 0)
+	    (old-symbol-name (if (stringp old) old
+			       (symbol-name old))))
+	(goto-char (point-min))
+	(while (not (eobp))
+	  (let* ((orig-sexp (progn (forward-sexp) (sexp-at-point)))
+		 (sexp-bds (bounds-of-thing-at-point 'sexp))
+		 (sexp-car (and orig-sexp (listp orig-sexp) (car orig-sexp)))
+		 (sexp-fun (and sexp-car (symbolp sexp-car) (symbol-name sexp-car))))
+	    (when (and sexp-fun (string-equal old-symbol-name sexp-fun))
+	      (setq count (1+ count))
+	      (delete-region (car sexp-bds) (cdr sexp-bds))
+	      (goto-char (car sexp-bds))
+	      (insert (with-output-to-string
+			(pp (append (list new)
+				    (if (and max-forms
+					     (numberp max-forms)
+					     (< max-forms (length orig-sexp)))
+					(seq-take (cdr orig-sexp) (abs max-forms))
+				      (cdr orig-sexp))))))
+	      (delete-char -1))))
+	(message "Made %d replacement%s." count (if (not (= count 1)) "s" "")))))
+#+END_SRC
+
 * Programming                                                   :programming:
 
 #+BEGIN_SRC elisp :exports none


### PR DESCRIPTION
New (first) *** under Packages called "Emacs Lisp Package Development" with a single item called "Always document variables".  Function for stripping out references from source is also included.  I did not add in any comment or other separation in rendered source for the new sub-section added under *Packages*.  Thanks for any tips on offering such contributions going forward!